### PR TITLE
Use resolver 2 and limit parser logs feature to root crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,16 +4,17 @@ name = "root"
 
 [dependencies]
 grammar.workspace = true
-parser.workspace = true
+parser = { workspace = true, features = ["logs"] }
 
 [features]
 logs = ["parser/logs"]
 
 [workspace]
+resolver = "2"
 default-members = [".", "grammar", "parser"]
 members = ["grammar", "parser"]
 
 [workspace.dependencies]
 root = {path = "."}
 grammar = {path = "grammar"}
-parser = {path = "parser", features = ["logs"]}
+parser = {path = "parser"}


### PR DESCRIPTION
## Summary
- add cargo resolver v2 for workspace
- remove default `logs` feature from parser workspace dependency
- enable parser's `logs` feature only in the root crate

## Testing
- `cargo test -p grammar --test test -- --show-output`

------
https://chatgpt.com/codex/tasks/task_e_68c1a2d626808331b88c78a80e9c162f